### PR TITLE
Propagate status to generated matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Let's break down what will happen here with a few examples:
     </tr>
 </table>
 
+### Change statuses
+
 Each matrix entry in the output JSON will also be annotated with an additional `reason` field that can help handling corner-cases like deleting a directory. If all matches of a set of groups have the same status, the `reason` field will be set to it.
 
 Example: if you use pattern `(?P<module>database-us|database-fr)` and all files in the `database-us` directory are deleted, the job matrix will look like:

--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ Let's break down what will happen here with a few examples:
     </tr>
 </table>
 
+Each matrix entry in the output JSON will also be annotated with an additional `reason` field that can help handling corner-cases like deleting a directory. If all matches of a set of groups have the same status, the `reason` field will be set to it.
+
+Example: if you use pattern `(?P<module>database-us|database-fr)` and all files in the `database-us` directory are deleted, the job matrix will look like:
+
+```json
+[
+    {
+        "module": "database-us",
+        "reason": "deleted"
+    },
+    {
+        "module": "database-fr",
+        "reason": "?"
+    }
+]
+```
+
+The same applies to any status, like `added` or `modified`.
+
+Note: if a pattern matching to the same set of groups were caused by multiple type of changes, the `reason` field is marked as `?`.
+
+
 ## Reference
 
 <table>
@@ -166,14 +188,6 @@ Let's break down what will happen here with a few examples:
         <td>no</td>
         <td>
             similar to the 'defaults' flag, except we match changed files on the provided UNIX-style glob pattern
-        </td>
-    </tr>
-    <tr>
-        <td>ignore-deleted-files</td>
-        <td>boolean</td>
-        <td>no</td>
-        <td>
-            if true, ignore deleted files
         </td>
     </tr>
 </table>

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -36,7 +36,7 @@ def generate_matrix(
     matched_default_patterns = [
         pattern
         for pattern in default_patterns
-        if fnmatch.filter(changed_files, pattern)
+        if fnmatch.filter((c for c, _ in changed_files), pattern)
     ]
 
     if matched_default_patterns:

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -16,7 +16,7 @@ from requests.auth import HTTPBasicAuth
 
 
 def generate_matrix(
-    payload: dict, include_regex: str, defaults=False, default_patterns=[]
+    payload: dict, include_regex: str, defaults=False, default_patterns=[], default_dir=os.getenv("GITHUB_WORKSPACE", os.curdir)
 ):
     include_regex = re.compile(include_regex, re.M | re.S)
 
@@ -47,8 +47,7 @@ def generate_matrix(
         print(
             "Listing all files/directories in repository matching the provided pattern"
         )
-        cwd = os.getenv("GITHUB_WORKSPACE", os.curdir)
-        default_files = [os.path.relpath(os.path.join(path, f), cwd) for path, _, files in os.walk(cwd) for f in files]
+        default_files = [(os.path.relpath(os.path.join(path, f), default_dir), "default") for path, _, files in os.walk(default_dir) for f in files]
         update_matches(default_files)
 
     # mark matrix entries with a status if all its matches have the same status
@@ -56,7 +55,6 @@ def generate_matrix(
     for (groups, statuses) in matches.items():
         groups["reason"] = statuses.pop() if len(statuses) == 1 else "?"
         matrix.append(groups)
-
 
     # convert back to a dict (hashable, serializable)
     return sorted(matrix)

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -27,7 +27,12 @@ def generate_matrix(
         for (filename, status) in files:
             match = include_regex.match(filename)
             if match:
-                key = hdict(match.groupdict() if match.groupdict() else {"path": filename})
+                if match.groupdict():
+                    if "reason" in match.groupdict().keys():
+                        raise ValueError("reason is a reserved name for the job matrix")
+                    key = hdict(match.groupdict())
+                else:
+                    key = hdict({"path": filename})
                 matches[key].add(status)
 
     update_matches(changed_files)

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -2,6 +2,9 @@
 
 import unittest
 import neo
+import os
+import tempfile
+from pathlib import Path
 
 
 class TestChangedFiles(unittest.TestCase):
@@ -17,6 +20,28 @@ class TestChangedFiles(unittest.TestCase):
                 },
             )
         )
+
+    def test_no_changes_with_defaults(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(os.path.join(d, "staging.txt")).touch()
+            Path(os.path.join(d, "live.txt")).touch()
+            self.assertCountEqual(
+                neo.generate_matrix(
+                    include_regex="(?P<environment>staging|live)",
+                    defaults=True,
+                    default_dir=d,
+                    payload={
+                        "files": [
+                            {"filename": "clusters", "status": "modified"},
+                            {"filename": "blah", "status": "modified"},
+                        ]
+                    },
+                ),
+                [
+                    {"environment": "staging", "reason": "default"},
+                    {"environment": "live", "reason": "default"},
+                ],
+            )
 
     def test_changes_groups_level1(self):
         self.assertCountEqual(

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -8,7 +8,12 @@ class TestChangedFiles(unittest.TestCase):
     def test_no_changes(self):
         self.assertFalse(
             neo.generate_matrix(
-                include_regex="clusters/.*", changed_files=["clusters", "blah"]
+                include_regex="clusters/.*", payload={
+                    "files": [
+                        {"filename": "clusters", "status": "changed"},
+                        {"filename": "blah", "status": "changed"}
+                    ]
+                }
             )
         )
 
@@ -16,11 +21,13 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/.*",
-                changed_files=[
-                    "clusters/staging/app",
-                    "clusters/staging/demo",
-                    "clusters/live/app",
-                ],
+                payload={
+                    "files": [
+                        {"filename": "clusters/staging/app", "status": "changed"},
+                        {"filename": "clusters/staging/demo", "status": "changed"},
+                        {"filename": "clusters/live/app", "status": "changed"},
+                    ]
+                }
             ),
             [{"environment": "staging"}, {"environment": "live"}],
         )
@@ -29,11 +36,13 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/(?P<namespace>\w+)",
-                changed_files=[
-                    "clusters/staging/app",
-                    "clusters/live/app",
-                    "clusters/staging/demo",
-                ],
+                payload={
+                    "files": [
+                        {"filename": "clusters/staging/app", "status": "changed"},
+                        {"filename": "clusters/live/app", "status": "changed"},
+                        {"filename": "clusters/staging/demo", "status": "changed"},
+                    ]
+                }
             ),
             [
                 {"environment": "staging", "namespace": "app"},
@@ -46,12 +55,14 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/.*",
-                changed_files=[
-                    "clusters/staging/app",
-                    "clusters/live/app",
-                    "clusters/staging/demo",
-                    "my_other_file/hello",
-                ],
+                payload={
+                    "files": [
+                        {"filename": "clusters/staging/app", "status": "changed"},
+                        {"filename": "clusters/live/app", "status": "changed"},
+                        {"filename": "clusters/staging/demo", "status": "changed"},
+                        {"filename": "my_other_file/hello", "status": "changed"},
+                    ]
+                }
             ),
             [
                 {"path": "clusters/staging/app"},
@@ -64,12 +75,14 @@ class TestChangedFiles(unittest.TestCase):
         self.assertListEqual(
             neo.generate_matrix(
                 include_regex="clusters/.*",
-                changed_files=[
-                    "my_other_file/hello",
-                    "clusters/live/app",
-                    "clusters/staging/app",
-                    "clusters/staging/demo",
-                ],
+                payload={
+                    "files": [
+                        {"filename": "my_other_file/hello", "status": "changed"},
+                        {"filename": "clusters/live/app", "status": "changed"},
+                        {"filename": "clusters/staging/app", "status": "changed"},
+                        {"filename": "clusters/staging/demo", "status": "changed"},
+                    ]
+                },
             ),
             [
                 {"path": "clusters/live/app"},


### PR DESCRIPTION
For each combination of matched groups, if all matches have the same `status` (`added`, `modified`, `removed` or `renamed`) it'll be added to the matrix in the `reason` field.

In a job, you could then use it in the `if` condition for example, with `matrix.reason != 'removed'`