### PR TITLE
Add support for GitHub API pagination

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: ./neo/tests.py -v
 
   neo:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
     required: false
   ignore-deleted-files:
     description: whether to ignore the deleted files or not
+    deprecationMessage: not used anymore
     default: "false"
     required: false
 outputs:
@@ -35,7 +36,6 @@ runs:
       run: |
         ${{ github.action_path }}/neo/neo.py \
           --pattern "${{ inputs.pattern }}" \
-          --ignore-deleted-files=${{inputs.ignore-deleted-files}} \
           --defaults=${{inputs.defaults}}
 branding:
   icon: git-pull-request

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -162,12 +162,6 @@ if __name__ == "__main__":
         required=True,
     )
     user_arg_group.add_argument(
-        "--ignore-deleted-files",
-        help="ignore deleted files",
-        type=strtobool,
-        default="false",
-    )
-    user_arg_group.add_argument(
         "--defaults",
         help="if any changed files match this pattern, recursively match all files in the current directory with the include pattern (a.k.a. run everything)",
         type=strtobool,

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -3,8 +3,8 @@
 from collections import defaultdict
 import os
 import argparse
-import glob
 import fnmatch
+import logging
 import requests
 import json
 import re
@@ -45,11 +45,11 @@ def generate_matrix(
     ]
 
     if matched_default_patterns:
-        print("Files changed in defaults patterns: ", matched_default_patterns)
+        logging.info("Files changed in defaults patterns: %s", matched_default_patterns)
 
     # if nothing changed, list all files/directories
     if (not matches and defaults) or matched_default_patterns:
-        print(
+        logging.info(
             "Listing all files/directories in repository matching the provided pattern"
         )
         default_files = [(os.path.relpath(os.path.join(path, f), default_dir), "default") for path, _, files in os.walk(default_dir) for f in files]
@@ -65,37 +65,32 @@ def generate_matrix(
     return sorted(matrix)
 
 
-def main(args):
-    session = requests.session()
-    session.hooks = {
-        "response": lambda r, *args, **kwargs: r.raise_for_status()
-    }
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    if "CI" in os.environ:
-        session.headers["Authorization"] = f"token {args.github_token}"
-    else:
-        session.auth = HTTPBasicAuth(args.github_username, args.github_token)
+def main(github_token: str, github_repository: str, github_base_ref: str, github_head_ref: str, include_regex: str, defaults: List[str] = [], default_patterns: List[str] = [], per_page: int = 0):
+    with requests.session() as session:
+        session.hooks = {
+            "response": lambda r, *args, **kwargs: r.raise_for_status()
+        }
+        # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+        session.headers["Authorization"] = f"token {github_token}"
+        if per_page:
+            session.params = { "per_page": per_page }
 
-    url = f"https://api.github.com/repos/{args.github_repository}/compare/{quote_plus(args.github_base_ref)}...{quote_plus(args.github_head_ref)}"
-    print("GitHub API request: ", url)
+        url = f"https://api.github.com/repos/{github_repository}/compare/{quote_plus(github_base_ref)}...{quote_plus(github_head_ref)}"
+        logging.info("GitHub API request: %s", url)
 
-    r = session.get(url)
-    files = r.json().get("files", [])
-    while link := r.links.get("next"):
-        next_page_url = link["url"]
-        print(f"Loading next page: {next_page_url}")
-        r = session.get(next_page_url)
-        files.extend(r.json().get("files", []))
+        r = session.get(url)
+        files = r.json().get("files", [])
+        while link := r.links.get("next"):
+            next_page_url = link["url"]
+            logging.info(f"Loading next page: {next_page_url}")
+            r = session.get(next_page_url)
+            files.extend(r.json().get("files", []))
 
     matrix = generate_matrix(
-        files, args.include_regex, args.defaults, args.default_patterns
+        files, include_regex, defaults, default_patterns
     )
 
-    print("Generated matrix: ", matrix)
-
-    if os.getenv("GITHUB_ACTIONS"):
-        files_json = json.dumps({"include": matrix})
-        print(f"::set-output name=matrix::{files_json}")
+    return matrix
 
 
 def github_webhook_ref(dest: str, option_strings: list):
@@ -140,18 +135,10 @@ if __name__ == "__main__":
     github_arg_group.add_argument(
         "--github-repository", action=env_default("GITHUB_REPOSITORY"), required=True
     )
-
     github_arg_group.add_argument(
         "--github-token", action=env_default("GITHUB_TOKEN"), required=True
     )
-    github_arg_group.add_argument(
-        "--github-username",
-        help="provide this argument if testing locally",
-        required=False,
-    )
-
     github_arg_group.add_argument("--github-head-ref", action=github_webhook_ref)
-
     github_arg_group.add_argument("--github-base-ref", action=github_webhook_ref)
 
     user_arg_group = parser.add_argument_group("user-provided")
@@ -174,5 +161,13 @@ if __name__ == "__main__":
         default=os.getenv("DEFAULT_PATTERNS", "").splitlines(),
     )
 
-    args = parser.parse_args()
-    main(args)
+    logging.basicConfig()
+
+    args = vars(parser.parse_args())
+
+    matrix = main(**args)
+    logging.info(matrix)
+
+    if os.getenv("GITHUB_ACTIONS"):
+        files_json = json.dumps({"include": matrix})
+        print(f"::set-output name=matrix::{files_json}")

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python3
+import neo
 
 import unittest
-import neo
 import os
 import tempfile
 from pathlib import Path
-
 
 class TestChangedFiles(unittest.TestCase):
     def test_no_changes(self):
         self.assertFalse(
             neo.generate_matrix(
                 include_regex="clusters/.*",
-                payload={
-                    "files": [
-                        {"filename": "clusters", "status": "modified"},
-                        {"filename": "blah", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters", "status": "modified"},
+                    {"filename": "blah", "status": "modified"},
+                ],
             )
         )
 
@@ -30,12 +27,10 @@ class TestChangedFiles(unittest.TestCase):
                     include_regex="(?P<environment>staging|live)",
                     defaults=True,
                     default_dir=d,
-                    payload={
-                        "files": [
-                            {"filename": "clusters", "status": "modified"},
-                            {"filename": "blah", "status": "modified"},
-                        ]
-                    },
+                    files=[
+                        {"filename": "clusters", "status": "modified"},
+                        {"filename": "blah", "status": "modified"},
+                    ],
                 ),
                 [
                     {"environment": "staging", "reason": "default"},
@@ -47,13 +42,11 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/.*",
-                payload={
-                    "files": [
-                        {"filename": "clusters/staging/app", "status": "modified"},
-                        {"filename": "clusters/staging/demo", "status": "modified"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters/staging/app", "status": "modified"},
+                    {"filename": "clusters/staging/demo", "status": "modified"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                ],
             ),
             [
                 {"environment": "staging", "reason": "modified"},
@@ -65,13 +58,11 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/(?P<namespace>\w+)",
-                payload={
-                    "files": [
-                        {"filename": "clusters/staging/app", "status": "modified"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                        {"filename": "clusters/staging/demo", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters/staging/app", "status": "modified"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                    {"filename": "clusters/staging/demo", "status": "modified"},
+                ],
             ),
             [
                 {"environment": "staging", "namespace": "app", "reason": "modified"},
@@ -84,14 +75,12 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/.*",
-                payload={
-                    "files": [
-                        {"filename": "clusters/staging/app", "status": "modified"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                        {"filename": "clusters/staging/demo", "status": "modified"},
-                        {"filename": "my_other_file/hello", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters/staging/app", "status": "modified"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                    {"filename": "clusters/staging/demo", "status": "modified"},
+                    {"filename": "my_other_file/hello", "status": "modified"},
+                ],
             ),
             [
                 {"path": "clusters/staging/app", "reason": "modified"},
@@ -104,14 +93,12 @@ class TestChangedFiles(unittest.TestCase):
         self.assertListEqual(
             neo.generate_matrix(
                 include_regex="clusters/.*",
-                payload={
-                    "files": [
-                        {"filename": "my_other_file/hello", "status": "modified"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                        {"filename": "clusters/staging/app", "status": "modified"},
-                        {"filename": "clusters/staging/demo", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "my_other_file/hello", "status": "modified"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                    {"filename": "clusters/staging/app", "status": "modified"},
+                    {"filename": "clusters/staging/demo", "status": "modified"},
+                ],
             ),
             [
                 {"path": "clusters/live/app", "reason": "modified"},
@@ -124,13 +111,11 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/.*",
-                payload={
-                    "files": [
-                        {"filename": "clusters/staging/app", "status": "removed"},
-                        {"filename": "clusters/staging/demo", "status": "removed"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters/staging/app", "status": "removed"},
+                    {"filename": "clusters/staging/demo", "status": "removed"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                ],
             ),
             [
                 {"environment": "staging", "reason": "removed"},
@@ -142,13 +127,11 @@ class TestChangedFiles(unittest.TestCase):
         self.assertCountEqual(
             neo.generate_matrix(
                 include_regex="clusters/(?P<environment>\w+)/.*",
-                payload={
-                    "files": [
-                        {"filename": "clusters/staging/app", "status": "removed"},
-                        {"filename": "clusters/staging/demo", "status": "modified"},
-                        {"filename": "clusters/live/app", "status": "modified"},
-                    ]
-                },
+                files=[
+                    {"filename": "clusters/staging/app", "status": "removed"},
+                    {"filename": "clusters/staging/demo", "status": "modified"},
+                    {"filename": "clusters/live/app", "status": "modified"},
+                ],
             ),
             [
                 {"environment": "staging", "reason": "updated"},

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -140,5 +140,20 @@ class TestChangedFiles(unittest.TestCase):
         )
 
 
+class IntegrationTest(unittest.TestCase):
+
+    empty_repo_commit_sha = "6b5794416e6750d16fb126a04eadb681349e6947"
+    initial_import_commit_sha = "191fe221420a833dc9a43d3338c1d94ccab94ea6"
+
+    def test_basic(self):
+        matrix = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*")
+        self.assertEqual(len(matrix), 5)
+
+    def test_pagination(self):
+        unpaginated_result = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*")
+        paginated_result = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*", per_page=1)
+        self.assertListEqual(unpaginated_result, paginated_result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from pathlib import Path
 
+
 class TestChangedFiles(unittest.TestCase):
     def test_no_changes(self):
         self.assertFalse(
@@ -146,12 +147,31 @@ class IntegrationTest(unittest.TestCase):
     initial_import_commit_sha = "191fe221420a833dc9a43d3338c1d94ccab94ea6"
 
     def test_basic(self):
-        matrix = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*")
+        matrix = neo.main(
+            os.getenv("GITHUB_TOKEN"),
+            "hellofresh/action-changed-files",
+            self.empty_repo_commit_sha,
+            self.initial_import_commit_sha,
+            ".*",
+        )
         self.assertEqual(len(matrix), 5)
 
     def test_pagination(self):
-        unpaginated_result = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*")
-        paginated_result = neo.main(os.getenv("GITHUB_TOKEN"), "hellofresh/action-changed-files", self.empty_repo_commit_sha, self.initial_import_commit_sha, ".*", per_page=1)
+        unpaginated_result = neo.main(
+            os.getenv("GITHUB_TOKEN"),
+            "hellofresh/action-changed-files",
+            self.empty_repo_commit_sha,
+            self.initial_import_commit_sha,
+            ".*",
+        )
+        paginated_result = neo.main(
+            os.getenv("GITHUB_TOKEN"),
+            "hellofresh/action-changed-files",
+            self.empty_repo_commit_sha,
+            self.initial_import_commit_sha,
+            ".*",
+            per_page=1,
+        )
         self.assertListEqual(unpaginated_result, paginated_result)
 
 


### PR DESCRIPTION
Resolves #15

Additional refactoring was conducted to be able to test `neo.main()`:

* Switch `neo.main` to named arguments instead of using the `argparse.Argument` object directly
* Add two E2E smoke tests that work with the live GitHub API on this specific repo