### PR TITLE
Ees 8069 handle bulk changes to repositories

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.neo.outputs.matrix ) }}
     steps:
-      - name: Echo Matrix
+      - name: Echo Matrix Directory
         run: echo ${{ matrix.dir }}
 
       - name: Echo Matrix Length

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.neo.outputs.matrix }}
+      matrix-length: ${{ steps.neo.outputs.matrix-length }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -45,5 +46,8 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.neo.outputs.matrix ) }}
     steps:
-      - name: Echo
+      - name: Echo Matrix
         run: echo ${{ matrix.dir }}
+
+      - name: Echo Matrix Length
+        run: echo ${{ needs.neo.outputs.matrix-length }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ outputs:
   matrix:
     description: the output job matrix
     value: ${{ steps.neo.outputs.matrix }}
+  matrix-length:
+    description: the length of the matrix
+    value: ${{ steps.neo.outputs.matrix-length }}
 runs:
   using: composite
   steps:

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -143,6 +143,7 @@ def github_webhook_ref(dest: str, option_strings: list):
 def set_github_actions_output(matrix: List):
     files_json = json.dumps({"include": matrix})
     print(f"::set-output name=matrix::{files_json}")
+    print(f"::set-output name=matrix-length::{len(matrix)}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -140,6 +140,9 @@ def github_webhook_ref(dest: str, option_strings: list):
         required=True, dest=dest, option_strings=option_strings
     )
 
+def set_github_actions_output(matrix: List):
+    files_json = json.dumps({"include": matrix})
+    print(f"::set-output name=matrix::{files_json}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -182,5 +185,4 @@ if __name__ == "__main__":
     logging.info(matrix)
 
     if os.getenv("GITHUB_ACTIONS"):
-        files_json = json.dumps({"include": matrix})
-        print(f"::set-output name=matrix::{files_json}")
+        set_github_actions_output(matrix)

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -158,12 +158,12 @@ class TestChangedFiles(unittest.TestCase):
             neo.set_github_actions_output(matrix)
 
         output = f.getvalue()
-        expectedOutput = json.dumps({"include": matrix})
+        expected_matrix_output = json.dumps({"include": matrix})
         self.assertEqual(
-                f"::set-output name=matrix::{expectedOutput}\n",
+                f"""::set-output name=matrix::{expected_matrix_output}
+::set-output name=matrix-length::3\n""",
                 output,
                 )
-
 
 
 class IntegrationTest(unittest.TestCase):

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import neo
 
-import unittest
+import contextlib
+import io
+import json
 import os
 import tempfile
+import unittest
 from pathlib import Path
 
 
@@ -139,6 +142,28 @@ class TestChangedFiles(unittest.TestCase):
                 {"environment": "live", "reason": "modified"},
             ],
         )
+
+    def test_github_outputs(self):
+        matrix = neo.generate_matrix(
+            include_regex="clusters/.*",
+            files=[
+                {"filename": "clusters/staging/app", "status": "modified"},
+                {"filename": "clusters/live/app", "status": "modified"},
+                {"filename": "clusters/staging/demo", "status": "modified"},
+                {"filename": "my_other_file/hello", "status": "modified"},
+            ]
+        )
+
+        with contextlib.redirect_stdout(io.StringIO()) as f:
+            neo.set_github_actions_output(matrix)
+
+        output = f.getvalue()
+        expectedOutput = json.dumps({"include": matrix})
+        self.assertEqual(
+                f"::set-output name=matrix::{expectedOutput}\n",
+                output,
+                )
+
 
 
 class IntegrationTest(unittest.TestCase):


### PR DESCRIPTION
[EES-8069](https://hellofresh.atlassian.net/browse/EES-8069)

This adds a 'matrix-length' output to the action.
Github actions expression language doesn't ship with a `len()` function. Adding the length to the action should avoid extra work on the actions consumer, such as using jq to get the length of the matrix manually.