### PR TITLE
Bump checkout action to v3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -28,7 +28,7 @@ jobs:
       matrix-length: ${{ steps.neo.outputs.matrix-length }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Generate matrix
         id: neo
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     # required to compare the pattern on the files in the repo
     - if: inputs.defaults || inputs.default-patterns != ''
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - id: neo
       shell: bash


### PR DESCRIPTION
Checkout action can be updated to v3.0 - 3.1
https://github.com/actions/checkout/releases/tag/v3.1.0

The main change from 2->3 is the nodejs runtime update to 16.x
https://github.com/actions/checkout/releases/tag/v3.0.0

Resolves #18 