### PR TITLE
CRS-3585 maintain `reason` irrespective of default patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/hellofresh/action-changed-files?style=for-the-badge)
 ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hellofresh/action-changed-files?style=for-the-badge)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/hellofresh/action-changed-files/Test?label=Status&style=for-the-badge)
-
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/hellofresh/action-changed-files/test.yaml?label=Status&style=for-the-badge&branch=master)
 ![GitHub last commit](https://img.shields.io/github/last-commit/hellofresh/action-changed-files?style=for-the-badge)
 ![GitHub Release Date](https://img.shields.io/github/release-date/hellofresh/action-changed-files?style=for-the-badge)
 ![GitHub issues](https://img.shields.io/github/issues-raw/hellofresh/action-changed-files?style=for-the-badge)

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -13,12 +13,13 @@ from urllib.parse import quote_plus
 from common import env_default, hdict, strtobool
 
 
-def update_matches(files, include_regex):
+def update_matches(files, include_regex, old_matches=defaultdict(set), ):
     """
     The update_matches function takes a list of files and their statuses,
     and returns a dictionary mapping the job matrix keys to sets of statuses.
     For example:
 
+    :param old_matches: old matches object to update
     :param files: Store the files that are found in the directory
     :param include_regex: Filter the files that are included in the job matrix
     :return: A dictionary of dictionaries
@@ -33,7 +34,10 @@ def update_matches(files, include_regex):
                 key = hdict(match.groupdict())
             else:
                 key = hdict({"path": filename})
+            if key in list(old_matches.keys()):
+                status = old_matches.pop(key).pop()
             matches[key].add(status)
+
     return matches
 
 
@@ -86,8 +90,7 @@ def generate_matrix(
             for path, _, files in os.walk(default_dir)
             for f in files
         ]
-        matches = update_matches(default_files, include_regex)
-
+        matches = update_matches( default_files, include_regex, matches)
     # mark matrix entries with a status if all its matches have the same status
     status_matrix = []
     for (groups, statuses) in matches.items():

--- a/neo/tests.py
+++ b/neo/tests.py
@@ -22,6 +22,47 @@ class TestChangedFiles(unittest.TestCase):
             )
         )
 
+    def test_no_changes_with_default_pattern(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(os.path.join(d, "staging.txt")).touch()
+            Path(os.path.join(d, "live.txt")).touch()
+            self.assertEqual(
+                neo.generate_matrix(
+                    include_regex="(?P<environment>staging|live)",
+                    default_patterns=["clusters/**"],
+                    default_dir=d,
+                    files=[
+                        {"filename": "blah", "status": "modified"},
+                        {"filename": "clusters/sample.json", "status": "modified"},
+                    ],
+                ),
+                [
+                    {'environment': 'live', 'reason': 'default'},
+                    {'environment': 'staging', 'reason': 'default'}
+                ],
+            )
+
+    def test_changes_with_default_pattern(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(os.path.join(d, "staging.txt")).touch()
+            Path(os.path.join(d, "live.txt")).touch()
+            self.assertEqual(
+                neo.generate_matrix(
+                    include_regex="(?P<environment>staging|live)",
+                    default_patterns=["clusters/**"],
+                    default_dir=d,
+                    files=[
+                        {"filename": "blah", "status": "modified"},
+                        {"filename": "clusters/sample.json", "status": "modified"},
+                        {"filename": "staging.txt", "status": "modified"},
+                    ],
+                ),
+                [
+                    {'environment': 'live', 'reason': 'default'},
+                    {'environment': 'staging', 'reason': 'modified'}
+                ],
+            )
+
     def test_no_changes_with_defaults(self):
         with tempfile.TemporaryDirectory() as d:
             Path(os.path.join(d, "staging.txt")).touch()


### PR DESCRIPTION
## Change
If the matrix is generated via `default_patterns`, every matrix path `reason` is overridden to `default`. 
Do not override reason of path/file even if default pattern is the trigger and maintain original reason/status from GitHub API 

## UseCase
This will allow us to push changes to default trigger paths and normal code changes in the same PR and still generate matrix for conditionals like `reason!=default`

## Added 2 test cases for the same scenario 
- `test_no_changes_with_default_pattern`
no changes to files but matrix generated by default pattern hence giving every matrix value a status of `default`

- `test_changes_with_default_pattern`
changes to files but matrix generated by default pattern hence giving every matrix value a status of `default` while maintaining the `modified` status of changed files 

### Added Docs change 
Updated status badge
https://github.com/badges/shields/issues/8671