### PR TITLE
Fix the action incorrect base ref sha by providing the SHA arguments for the Github head and base commits to Neo.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,9 @@ runs:
       run: |
         ${{ github.action_path }}/neo/neo.py \
           --pattern "${{ inputs.pattern }}" \
-          --defaults=${{inputs.defaults}} >> $GITHUB_OUTPUT
+          --defaults=${{inputs.defaults}} >> $GITHUB_OUTPUT \
+          --github-head-ref=${{ github.event.pull_request.head.sha }} \
+          --github-base-ref=${{ github.event.pull_request.base.sha }}
 
 branding:
   icon: git-pull-request


### PR DESCRIPTION
Issue: https://github.com/hellofresh/action-changed-files/issues/29