### PR TITLE
feat: Allowing run on pull_request_target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .vscode/*
+.idea/*

--- a/neo/neo.py
+++ b/neo/neo.py
@@ -157,7 +157,7 @@ def github_webhook_ref(dest: str, option_strings: list):
     if github_event_path:
         with open(github_event_path, "r") as fp:
             github_event = json.load(fp)
-            if github_event_name == "pull_request":
+            if github_event_name in ["pull_request", "pull_request_target"]:
                 return argparse.Action(
                     default=github_event["pull_request"]["head"]["sha"]
                     if is_github_head_ref


### PR DESCRIPTION
* Allowing action to run when workflow trigger is pull_request_target.
* The payload from the two events is identical according to [GitHub blog post on the subject](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload.