### PR TITLE
Fix output name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ jobs:
   build:
     needs: [ generate-matrix ]
     strategy:
-      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix-build) }}
-    if: ${{ fromJson(needs.generate-matrix.outputs.matrix-build).include[0] }}
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix-library) }}
+    if: ${{ fromJson(needs.generate-matrix.outputs.matrix-library).include[0] }}
     steps:
         - name: Building library
           run: echo "Building ${{ matrix.lib }}"


### PR DESCRIPTION
Hi!

The README currently generates a `matrix-library` output that is never used, and uses a `matrix-build` output that is never generated. Unless I'm more confused than I think I am about how GitHub workflows work, these should match, and the example as given wouldn't work.

Now the `build` job uses the `matrix-library` output.

Cheers!
