### PR TITLE
chore: pin actions/checkout to v6 SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
   steps:
     # required to compare the pattern on the files in the repo
     - if: inputs.defaults || inputs.default-patterns != ''
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - id: neo
       shell: bash


### PR DESCRIPTION
For safety.